### PR TITLE
Erreur de frappe "Android" au lieu de "iOS"

### DIFF
--- a/src/components/Tutorial.vue
+++ b/src/components/Tutorial.vue
@@ -195,7 +195,7 @@ export default {
 
 
     <section v-if="plateforme === 'ios'">
-      <p class="text-[#2E2E2E] text-4xl font-bold" :class="{ 'text-[#FFFFFF]': !theme }">Changez les DNS sur Android</p>
+      <p class="text-[#2E2E2E] text-4xl font-bold" :class="{ 'text-[#FFFFFF]': !theme }">Changez les DNS sur iOS</p>
 
       <ol class="list-decimal text-[#2E2E2E] mt-12 mx-2 md:mx-8" :class="{ 'text-[#FFFFFF]': !theme }">
         <li class="mt-10">


### PR DESCRIPTION
Au niveau du tutoriel pour iOS, l'intitulé indique "Changez les DNS sur Android" au lieu de "Changez les DNS sur iOS".